### PR TITLE
Added pebble language configurations into monaco-editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
 				"shelljs": "^0.8.5",
 				"style-loader": "^3.3.1",
 				"terser": "^5.14.2",
-				"ts-node": "^10.6.0",
+				"ts-node": "^10.9.2",
 				"typescript": "^5.4.5",
 				"vite": "^3.2.8",
 				"vscode-css-languageservice": "6.2.14",
@@ -154,25 +154,28 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/@cspotcode/source-map-consumer": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
-			"integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 12"
-			}
-		},
 		"node_modules/@cspotcode/source-map-support": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
-			"integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@cspotcode/source-map-consumer": "0.8.0"
+				"@jridgewell/trace-mapping": "0.3.9"
 			},
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.0.3",
+				"@jridgewell/sourcemap-codec": "^1.4.10"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -6806,12 +6809,13 @@
 			}
 		},
 		"node_modules/ts-node": {
-			"version": "10.6.0",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.6.0.tgz",
-			"integrity": "sha512-CJen6+dfOXolxudBQXnVjRVvYTmTWbyz7cn+xq2XTsvnaXbHqr4gXSCNbS2Jj8yTZMuGwUoBESLaOkLascVVvg==",
+			"version": "10.9.2",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+			"integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@cspotcode/source-map-support": "0.7.0",
+				"@cspotcode/source-map-support": "^0.8.0",
 				"@tsconfig/node10": "^1.0.7",
 				"@tsconfig/node12": "^1.0.7",
 				"@tsconfig/node14": "^1.0.0",
@@ -6822,12 +6826,13 @@
 				"create-require": "^1.1.0",
 				"diff": "^4.0.1",
 				"make-error": "^1.1.1",
-				"v8-compile-cache-lib": "^3.0.0",
+				"v8-compile-cache-lib": "^3.0.1",
 				"yn": "3.1.1"
 			},
 			"bin": {
 				"ts-node": "dist/bin.js",
 				"ts-node-cwd": "dist/bin-cwd.js",
+				"ts-node-esm": "dist/bin-esm.js",
 				"ts-node-script": "dist/bin-script.js",
 				"ts-node-transpile-only": "dist/bin-transpile.js",
 				"ts-script": "dist/bin-script-deprecated.js"
@@ -7017,10 +7022,11 @@
 			"dev": true
 		},
 		"node_modules/v8-compile-cache-lib": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz",
-			"integrity": "sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA==",
-			"dev": true
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/vite": {
 			"version": "3.2.8",
@@ -7595,19 +7601,25 @@
 				}
 			}
 		},
-		"@cspotcode/source-map-consumer": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
-			"integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
-			"dev": true
-		},
 		"@cspotcode/source-map-support": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
-			"integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
 			"dev": true,
 			"requires": {
-				"@cspotcode/source-map-consumer": "0.8.0"
+				"@jridgewell/trace-mapping": "0.3.9"
+			},
+			"dependencies": {
+				"@jridgewell/trace-mapping": {
+					"version": "0.3.9",
+					"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+					"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+					"dev": true,
+					"requires": {
+						"@jridgewell/resolve-uri": "^3.0.3",
+						"@jridgewell/sourcemap-codec": "^1.4.10"
+					}
+				}
 			}
 		},
 		"@esbuild/aix-ppc64": {
@@ -12144,12 +12156,12 @@
 			}
 		},
 		"ts-node": {
-			"version": "10.6.0",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.6.0.tgz",
-			"integrity": "sha512-CJen6+dfOXolxudBQXnVjRVvYTmTWbyz7cn+xq2XTsvnaXbHqr4gXSCNbS2Jj8yTZMuGwUoBESLaOkLascVVvg==",
+			"version": "10.9.2",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+			"integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
 			"dev": true,
 			"requires": {
-				"@cspotcode/source-map-support": "0.7.0",
+				"@cspotcode/source-map-support": "^0.8.0",
 				"@tsconfig/node10": "^1.0.7",
 				"@tsconfig/node12": "^1.0.7",
 				"@tsconfig/node14": "^1.0.0",
@@ -12160,7 +12172,7 @@
 				"create-require": "^1.1.0",
 				"diff": "^4.0.1",
 				"make-error": "^1.1.1",
-				"v8-compile-cache-lib": "^3.0.0",
+				"v8-compile-cache-lib": "^3.0.1",
 				"yn": "3.1.1"
 			},
 			"dependencies": {
@@ -12286,9 +12298,9 @@
 			"dev": true
 		},
 		"v8-compile-cache-lib": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz",
-			"integrity": "sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
 			"dev": true
 		},
 		"vite": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
 		"shelljs": "^0.8.5",
 		"style-loader": "^3.3.1",
 		"terser": "^5.14.2",
-		"ts-node": "^10.6.0",
+		"ts-node": "^10.9.2",
 		"typescript": "^5.4.5",
 		"vite": "^3.2.8",
 		"vscode-css-languageservice": "6.2.14",

--- a/samples/browser-amd-editor/index.html
+++ b/samples/browser-amd-editor/index.html
@@ -9,9 +9,9 @@
 		<div id="container" style="width: 800px; height: 600px; border: 1px solid grey"></div>
 
 		<!-- OR ANY OTHER AMD LOADER HERE INSTEAD OF loader.js -->
-		<script src="../../node_modules/monaco-editor-core/min/vs/loader.js"></script>
+		<script src="../../out/monaco-editor/dev/vs/loader.js"></script>
 		<script>
-			require.config({ paths: { vs: '../../node_modules/monaco-editor-core/min/vs' } });
+			require.config({ paths: { vs: '../../out/monaco-editor/dev/vs' } });
 
 			require(['vs/editor/editor.main'], function () {
 				var editor = monaco.editor.create(document.getElementById('container'), {

--- a/samples/browser-amd-editor/index.html
+++ b/samples/browser-amd-editor/index.html
@@ -9,14 +9,73 @@
 		<div id="container" style="width: 800px; height: 600px; border: 1px solid grey"></div>
 
 		<!-- OR ANY OTHER AMD LOADER HERE INSTEAD OF loader.js -->
-		<script src="../node_modules/monaco-editor/min/vs/loader.js"></script>
+		<script src="../../node_modules/monaco-editor-core/min/vs/loader.js"></script>
 		<script>
-			require.config({ paths: { vs: '../node_modules/monaco-editor/min/vs' } });
+			require.config({ paths: { vs: '../../node_modules/monaco-editor-core/min/vs' } });
 
 			require(['vs/editor/editor.main'], function () {
 				var editor = monaco.editor.create(document.getElementById('container'), {
-					value: ['function x() {', '\tconsole.log("Hello world!");', '}'].join('\n'),
-					language: 'javascript'
+					value: [
+						'import { MyDatum } from "./MyDatum";',
+						'import { MyAction } from "./MyAction";',
+						'',
+						'struct Datum {',
+						'    owner: string,',
+						'}',
+						'',
+						'struct Animal {',
+						'    Dog {',
+						'        name: string,',
+						'        barksCount: int,',
+						'    }',
+						'    Cat {',
+						'        name: string,',
+						'        color: string,',
+						'    }',
+						'    Fish {',
+						'        name: string,',
+						'    }',
+						'}',
+						'',
+						'function main({ tx, purpose }: ScriptContext)',
+						'{',
+						'    const [a, b, ...rest] = tx.inputs;',
+						'',
+						'    const Spending {',
+						'        utxoRef,',
+						'        maybeDatum: Just {',
+						'            value: datum as MyDatum',
+						'        }',
+						'    } = purpose;',
+						'',
+						'    let sumLove = 0;',
+						'',
+						'    assert tx.outputs.length() === 1 else "only one output allowed";',
+						'    assert sumLove >= 1000_000_000;',
+						'',
+						'    let a = 0;',
+						'    let b = 1;',
+						'    let c = 2;',
+						'',
+						'    for (let i = 0; i < 10; i++) {',
+						'        a += 1;',
+						'    }',
+						'',
+						'    match (purpose) {',
+						'        Spending { utxoRef, maybeDatum: Just{ value: datum as MyDatum } } => {}',
+						'        Minting { } => {}',
+						'        Certify { } => {}',
+						'        _ => {}',
+						'    }',
+						'',
+						'    trace a;',
+						'',
+						'    fail a === 1;',
+						'',
+						'    fail;',
+						'}'
+					].join('\n'),
+					language: 'pebble'
 				});
 			});
 		</script>

--- a/samples/browser-amd-editor/index.html
+++ b/samples/browser-amd-editor/index.html
@@ -9,73 +9,14 @@
 		<div id="container" style="width: 800px; height: 600px; border: 1px solid grey"></div>
 
 		<!-- OR ANY OTHER AMD LOADER HERE INSTEAD OF loader.js -->
-		<script src="../../out/monaco-editor/dev/vs/loader.js"></script>
+		<script src="../node_modules/monaco-editor/min/vs/loader.js"></script>
 		<script>
-			require.config({ paths: { vs: '../../out/monaco-editor/dev/vs' } });
+			require.config({ paths: { vs: '../node_modules/monaco-editor/min/vs' } });
 
 			require(['vs/editor/editor.main'], function () {
 				var editor = monaco.editor.create(document.getElementById('container'), {
-					value: [
-						'import { MyDatum } from "./MyDatum";',
-						'import { MyAction } from "./MyAction";',
-						'',
-						'struct Datum {',
-						'    owner: string,',
-						'}',
-						'',
-						'struct Animal {',
-						'    Dog {',
-						'        name: string,',
-						'        barksCount: int,',
-						'    }',
-						'    Cat {',
-						'        name: string,',
-						'        color: string,',
-						'    }',
-						'    Fish {',
-						'        name: string,',
-						'    }',
-						'}',
-						'',
-						'function main({ tx, purpose }: ScriptContext)',
-						'{',
-						'    const [a, b, ...rest] = tx.inputs;',
-						'',
-						'    const Spending {',
-						'        utxoRef,',
-						'        maybeDatum: Just {',
-						'            value: datum as MyDatum',
-						'        }',
-						'    } = purpose;',
-						'',
-						'    let sumLove = 0;',
-						'',
-						'    assert tx.outputs.length() === 1 else "only one output allowed";',
-						'    assert sumLove >= 1000_000_000;',
-						'',
-						'    let a = 0;',
-						'    let b = 1;',
-						'    let c = 2;',
-						'',
-						'    for (let i = 0; i < 10; i++) {',
-						'        a += 1;',
-						'    }',
-						'',
-						'    match (purpose) {',
-						'        Spending { utxoRef, maybeDatum: Just{ value: datum as MyDatum } } => {}',
-						'        Minting { } => {}',
-						'        Certify { } => {}',
-						'        _ => {}',
-						'    }',
-						'',
-						'    trace a;',
-						'',
-						'    fail a === 1;',
-						'',
-						'    fail;',
-						'}'
-					].join('\n'),
-					language: 'pebble'
+					value: ['function x() {', '\tconsole.log("Hello world!");', '}'].join('\n'),
+					language: 'javascript'
 				});
 			});
 		</script>

--- a/src/basic-languages/monaco.contribution.ts
+++ b/src/basic-languages/monaco.contribution.ts
@@ -84,3 +84,4 @@ import './vb/vb.contribution';
 import './wgsl/wgsl.contribution';
 import './xml/xml.contribution';
 import './yaml/yaml.contribution';
+import './pebble/pebble.contribution';

--- a/src/basic-languages/pebble/pebble.contribution.ts
+++ b/src/basic-languages/pebble/pebble.contribution.ts
@@ -1,0 +1,24 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { registerLanguage } from '../_.contribution';
+
+declare var AMD: any;
+declare var require: any;
+
+registerLanguage({
+	id: 'pebble',
+	extensions: ['.pebble'],
+	aliases: ['Pebble'],
+	loader: (): Promise<any> => {
+		if (AMD) {
+			return new Promise((resolve, reject) => {
+				require(['vs/basic-languages/pebble/pebble'], resolve, reject);
+			});
+		} else {
+			return import('./pebble');
+		}
+	}
+});

--- a/src/basic-languages/pebble/pebble.test.ts
+++ b/src/basic-languages/pebble/pebble.test.ts
@@ -1,0 +1,10 @@
+// /*---------------------------------------------------------------------------------------------
+//  *  Copyright (c) Microsoft Corporation. All rights reserved.
+//  *  Licensed under the MIT License. See License.txt in the project root for license information.
+//  *--------------------------------------------------------------------------------------------*/
+
+import { testTokenization } from '../test/testRunner';
+
+testTokenization('pebble', [
+	// TBD
+]);

--- a/src/basic-languages/pebble/pebble.test.ts
+++ b/src/basic-languages/pebble/pebble.test.ts
@@ -6,5 +6,173 @@
 import { testTokenization } from '../test/testRunner';
 
 testTokenization('pebble', [
-	// TBD
+	// Keywords
+	[
+		{
+			line: 'if (x > 0) { return x; }',
+			tokens: [
+				{ startIndex: 0, type: 'keyword.ts' }, // 'if'
+				{ startIndex: 2, type: '' }, // whitespace
+				{ startIndex: 3, type: 'delimiter.parenthesis.ts' }, // '('
+				{ startIndex: 4, type: 'identifier.ts' }, // 'x'
+				{ startIndex: 5, type: '' }, // whitespace
+				{ startIndex: 6, type: 'delimiter.angle.ts' }, // '>'
+				{ startIndex: 7, type: '' }, // whitespace
+				{ startIndex: 8, type: 'number.ts' }, // '0'
+				{ startIndex: 9, type: 'delimiter.parenthesis.ts' }, // ')'
+				{ startIndex: 10, type: '' }, // whitespace
+				{ startIndex: 11, type: 'delimiter.bracket.ts' }, // '{'
+				{ startIndex: 12, type: '' }, // whitespace
+				{ startIndex: 13, type: 'keyword.ts' }, // 'return'
+				{ startIndex: 19, type: '' }, // whitespace
+				{ startIndex: 20, type: 'identifier.ts' }, // 'x'
+				{ startIndex: 21, type: 'delimiter.ts' }, // ';'
+				{ startIndex: 22, type: '' }, // whitespace
+				{ startIndex: 23, type: 'delimiter.bracket.ts' } // '}'
+			]
+		}
+	],
+
+	// Operators
+	[
+		{
+			line: 'x = y + z - 10 * 2 / 5;',
+			tokens: [
+				{ startIndex: 0, type: 'identifier.ts' }, // 'x'
+				{ startIndex: 1, type: '' }, // whitespace
+				{ startIndex: 2, type: 'delimiter.ts' }, // '='
+				{ startIndex: 3, type: '' }, // whitespace
+				{ startIndex: 4, type: 'identifier.ts' }, // 'y'
+				{ startIndex: 5, type: '' }, // whitespace
+				{ startIndex: 6, type: 'delimiter.ts' }, // '+'
+				{ startIndex: 7, type: '' }, // whitespace
+				{ startIndex: 8, type: 'identifier.ts' }, // 'z'
+				{ startIndex: 9, type: '' }, // whitespace
+				{ startIndex: 10, type: 'delimiter.ts' }, // '-'
+				{ startIndex: 11, type: '' }, // whitespace
+				{ startIndex: 12, type: 'number.ts' }, // '10'
+				{ startIndex: 14, type: '' }, // whitespace
+				{ startIndex: 15, type: 'delimiter.ts' }, // '*'
+				{ startIndex: 16, type: '' }, // whitespace
+				{ startIndex: 17, type: 'number.ts' }, // '2'
+				{ startIndex: 18, type: '' }, // whitespace
+				{ startIndex: 19, type: 'delimiter.ts' }, // '/'
+				{ startIndex: 20, type: '' }, // whitespace
+				{ startIndex: 21, type: 'number.ts' }, // '5'
+				{ startIndex: 22, type: 'delimiter.ts' } // ';'
+			]
+		}
+	],
+
+	// Delimiters
+	[
+		{
+			line: '{ [ ( ) ] }',
+			tokens: [
+				{ startIndex: 0, type: 'delimiter.bracket.ts' }, // '{'
+				{ startIndex: 1, type: '' }, // whitespace
+				{ startIndex: 2, type: 'delimiter.square.ts' }, // '['
+				{ startIndex: 3, type: '' }, // whitespace
+				{ startIndex: 4, type: 'delimiter.parenthesis.ts' }, // '('
+				{ startIndex: 5, type: '' }, // whitespace
+				{ startIndex: 6, type: 'delimiter.parenthesis.ts' }, // ')'
+				{ startIndex: 7, type: '' }, // whitespace
+				{ startIndex: 8, type: 'delimiter.square.ts' }, // ']'
+				{ startIndex: 9, type: '' }, // whitespace
+				{ startIndex: 10, type: 'delimiter.bracket.ts' } // '}'
+			]
+		}
+	],
+
+	// Comments
+	[
+		{
+			line: '// This is a single-line comment',
+			tokens: [
+				{ startIndex: 0, type: 'comment.ts' } // Entire line
+			]
+		},
+		{
+			line: '/* This is a multi-line comment */',
+			tokens: [
+				{ startIndex: 0, type: 'comment.ts' } // Entire line
+			]
+		}
+	],
+
+	// Strings
+	[
+		{
+			line: 'let str = "Hello, world!";',
+			tokens: [
+				{ startIndex: 0, type: 'keyword.ts' }, // 'let'
+				{ startIndex: 3, type: '' }, // whitespace
+				{ startIndex: 4, type: 'identifier.ts' }, // 'str'
+				{ startIndex: 7, type: '' }, // whitespace
+				{ startIndex: 8, type: 'delimiter.ts' }, // '='
+				{ startIndex: 9, type: '' }, // whitespace
+				{ startIndex: 10, type: 'string.ts' }, // '"Hello, world!"'
+				{ startIndex: 25, type: 'delimiter.ts' } // ';'
+			]
+		},
+		{
+			line: "let str = 'Hello, world!';",
+			tokens: [
+				{ startIndex: 0, type: 'keyword.ts' }, // 'let'
+				{ startIndex: 3, type: '' }, // whitespace
+				{ startIndex: 4, type: 'identifier.ts' }, // 'str'
+				{ startIndex: 7, type: '' }, // whitespace
+				{ startIndex: 8, type: 'delimiter.ts' }, // '='
+				{ startIndex: 9, type: '' }, // whitespace
+				{ startIndex: 10, type: 'string.ts' }, // "'Hello, world!'"
+				{ startIndex: 25, type: 'delimiter.ts' } // ';'
+			]
+		}
+	],
+
+	// Numbers
+	[
+		{
+			line: 'const pi = 3.14;',
+			tokens: [
+				{ startIndex: 0, type: 'keyword.ts' }, // 'const'
+				{ startIndex: 5, type: '' }, // whitespace
+				{ startIndex: 6, type: 'identifier.ts' }, // 'pi'
+				{ startIndex: 8, type: '' }, // whitespace
+				{ startIndex: 9, type: 'delimiter.ts' }, // '='
+				{ startIndex: 10, type: '' }, // whitespace
+				{ startIndex: 11, type: 'number.float.ts' }, // '3.14'
+				{ startIndex: 15, type: 'delimiter.ts' } // ';'
+			]
+		},
+		{
+			line: 'let count = 123;',
+			tokens: [
+				{ startIndex: 0, type: 'keyword.ts' }, // 'let'
+				{ startIndex: 3, type: '' }, // whitespace
+				{ startIndex: 4, type: 'identifier.ts' }, // 'count'
+				{ startIndex: 9, type: '' }, // whitespace
+				{ startIndex: 10, type: 'delimiter.ts' }, // '='
+				{ startIndex: 11, type: '' }, // whitespace
+				{ startIndex: 12, type: 'number.ts' }, // '123'
+				{ startIndex: 15, type: 'delimiter.ts' } // ';'
+			]
+		}
+	],
+
+	// Folding Markers
+	[
+		{
+			line: '// #region',
+			tokens: [
+				{ startIndex: 0, type: 'comment.ts' } // Entire line
+			]
+		},
+		{
+			line: '// #endregion',
+			tokens: [
+				{ startIndex: 0, type: 'comment.ts' } // Entire line
+			]
+		}
+	]
 ]);

--- a/src/basic-languages/pebble/pebble.ts
+++ b/src/basic-languages/pebble/pebble.ts
@@ -1,0 +1,457 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { languages } from '../../fillers/monaco-editor-core';
+
+export const conf: languages.LanguageConfiguration = {
+	wordPattern: /(-?\d*\.\d\w*)|([^\`\@\~\!\%\^\&\*\(\)\-\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\?\s]+)/,
+
+	comments: {
+		lineComment: '//',
+		blockComment: ['/*', '*/']
+	},
+
+	brackets: [
+		['{', '}'],
+		['${', '}'],
+		['[', ']'],
+		['(', ')']
+	],
+
+	onEnterRules: [
+		{
+			// e.g. /** | */
+			beforeText: /^\s*\/\*\*(?!\/)([^\*]|\*(?!\/))*$/,
+			afterText: /^\s*\*\/$/,
+			action: {
+				indentAction: languages.IndentAction.IndentOutdent,
+				appendText: ' * '
+			}
+		},
+		{
+			// e.g. /** ...|
+			beforeText: /^\s*\/\*\*(?!\/)([^\*]|\*(?!\/))*$/,
+			action: {
+				indentAction: languages.IndentAction.None,
+				appendText: ' * '
+			}
+		},
+		{
+			// e.g.  * ...|
+			beforeText: /^(\t|(\ \ ))*\ \*(\ ([^\*]|\*(?!\/))*)?$/,
+			previousLineText: /^(?=^(\s*(\/\*\*|\*)).*)(?=(?!(\s*\*\/)))/,
+			action: {
+				indentAction: languages.IndentAction.None,
+				appendText: '* '
+			}
+		},
+		{
+			// e.g.  */|
+			beforeText: /^(\t|[ ])*[ ]\*\/\s*$/,
+			action: {
+				indentAction: languages.IndentAction.None,
+				removeText: 1
+			}
+		},
+		{
+			// e.g.  *-----*/|
+			beforeText: /^(\t|[ ])*[ ]\*[^/]*\*\/\s*$/,
+			action: {
+				indentAction: languages.IndentAction.None,
+				removeText: 1
+			}
+		},
+		{
+			// e.g.  *-----*/|
+			beforeText: /^\s*(\bcase\s.+:|\bdefault:)$/,
+			afterText: /^(?!\s*(\bcase\b|\bdefault\b))/,
+			action: {
+				indentAction: languages.IndentAction.Indent
+			}
+		},
+		{
+			// Decrease indentation after single line if/else if/else, for, or while
+			previousLineText: /^\s*(((else ?)?if|for|while)\s*\(.*\)\s*|else\s*)$/,
+			// But make sure line doesn't have braces or is not another if statement
+			beforeText: /^\s+([^{i\s]|i(?!f\b))/,
+			action: {
+				indentAction: languages.IndentAction.Outdent
+			}
+		},
+		{
+			// Indent when pressing enter from inside ()
+			beforeText: /^.*\([^)]*$/,
+			afterText: /^\s*\).*$/,
+			action: {
+				indentAction: languages.IndentAction.IndentOutdent,
+				appendText: '\t'
+			}
+		},
+		{
+			// Indent when pressing enter from inside {}
+			beforeText: /^.*\{[^}]*$/,
+			afterText: /^\s*\}.*$/,
+			action: {
+				indentAction: languages.IndentAction.IndentOutdent,
+				appendText: '\t'
+			}
+		},
+		{
+			// Indent when pressing enter from inside []
+			beforeText: /^.*\[[^\]]*$/,
+			afterText: /^\s*\].*$/,
+			action: {
+				indentAction: languages.IndentAction.IndentOutdent,
+				appendText: '\t'
+			}
+		},
+		{
+			// Add // when pressing enter from inside line comment
+			beforeText: /(?<!\\)(?<!\w:)\/\/.*/,
+			afterText: /^(?!\s*$).+/,
+			action: {
+				indentAction: languages.IndentAction.None,
+				appendText: '// '
+			}
+		}
+	],
+
+	autoClosingPairs: [
+		{ open: '{', close: '}' },
+		{ open: '[', close: ']' },
+		{ open: '(', close: ')' },
+		{ open: "'", close: "'", notIn: ['string', 'comment'] },
+		{ open: '`', close: '`', notIn: ['string', 'comment'] },
+		{ open: '"', close: '"', notIn: ['string'] },
+		{ open: '/**', close: ' */', notIn: ['string'] }
+	],
+
+	surroundingPairs: [
+		{ open: '{', close: '}' },
+		{ open: '[', close: ']' },
+		{ open: '(', close: ')' },
+		{ open: "'", close: "'" },
+		{ open: '"', close: '"' },
+		{ open: '`', close: '`' },
+		{ open: '<', close: '<' }
+	],
+
+	colorizedBracketPairs: [
+		['{', '}'],
+		['[', ']'],
+		['(', ')'],
+		['<', '>']
+	],
+
+	autoCloseBefore: ';:.,=}])>` \n\t',
+
+	folding: {
+		markers: {
+			start: new RegExp('^\\s*//\\s*#?region\\b'),
+			end: new RegExp('^\\s*//\\s*#?endregion\\b')
+		}
+	},
+
+	indentationRules: {
+		decreaseIndentPattern: new RegExp('^\\s*[\\}\\]\\)].*$'),
+		increaseIndentPattern: new RegExp('^.*(\\{[^}]*|\\([^)]*|\\[[^\\]]*)$'),
+		// e.g.  * ...| or */| or *-----*/|
+		unIndentedLinePattern: new RegExp(
+			'^(\\t|[ ])*[ ]\\*[^/]*\\*/\\s*$|^(\\t|[ ])*[ ]\\*/\\s*$|^(\\t|[ ])*\\*([ ]([^\\*]|\\*(?!/))*)?$'
+		),
+		indentNextLinePattern: new RegExp(
+			'^((.*=>\\s*)|((.*[^\\w]+|\\s*)(if|while|for)\\s*\\(.*\\)\\s*))$'
+		)
+	}
+};
+
+export const language = {
+	// Set defaultToken to invalid to see what you do not tokenize yet
+	defaultToken: 'invalid',
+	tokenPostfix: '.ts',
+
+	keywords: [
+		// Should match the keys of textToKeywordObj in
+		// https://github.com/microsoft/TypeScript/blob/master/src/compiler/scanner.ts
+		'abstract',
+		'any',
+		'as',
+		'asserts',
+		'bigint',
+		'boolean',
+		'break',
+		'case',
+		'catch',
+		'class',
+		'continue',
+		'const',
+		'constructor',
+		'debugger',
+		'declare',
+		'default',
+		'delete',
+		'do',
+		'else',
+		'enum',
+		'export',
+		'extends',
+		'false',
+		'finally',
+		'for',
+		'from',
+		'function',
+		'get',
+		'if',
+		'implements',
+		'import',
+		'in',
+		'infer',
+		'instanceof',
+		'interface',
+		'is',
+		'keyof',
+		'let',
+		'module',
+		'namespace',
+		'never',
+		'new',
+		'null',
+		'number',
+		'object',
+		'out',
+		'package',
+		'private',
+		'protected',
+		'public',
+		'override',
+		'readonly',
+		'require',
+		'global',
+		'return',
+		'satisfies',
+		'set',
+		'static',
+		'string',
+		'super',
+		'switch',
+		'symbol',
+		'this',
+		'throw',
+		'true',
+		'try',
+		'type',
+		'typeof',
+		'undefined',
+		'unique',
+		'unknown',
+		'var',
+		'void',
+		'while',
+		'with',
+		'yield',
+		'async',
+		'await',
+		'of'
+	],
+
+	operators: [
+		'<=',
+		'>=',
+		'==',
+		'!=',
+		'===',
+		'!==',
+		'=>',
+		'+',
+		'-',
+		'**',
+		'*',
+		'/',
+		'%',
+		'++',
+		'--',
+		'<<',
+		'</',
+		'>>',
+		'>>>',
+		'&',
+		'|',
+		'^',
+		'!',
+		'~',
+		'&&',
+		'||',
+		'??',
+		'?',
+		':',
+		'=',
+		'+=',
+		'-=',
+		'*=',
+		'**=',
+		'/=',
+		'%=',
+		'<<=',
+		'>>=',
+		'>>>=',
+		'&=',
+		'|=',
+		'^=',
+		'@'
+	],
+
+	// we include these common regular expressions
+	symbols: /[=><!~?:&|+\-*\/\^%]+/,
+	escapes: /\\(?:[abfnrtv\\"']|x[0-9A-Fa-f]{1,4}|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})/,
+	digits: /\d+(_+\d+)*/,
+	octaldigits: /[0-7]+(_+[0-7]+)*/,
+	binarydigits: /[0-1]+(_+[0-1]+)*/,
+	hexdigits: /[[0-9a-fA-F]+(_+[0-9a-fA-F]+)*/,
+
+	regexpctl: /[(){}\[\]\$\^|\-*+?\.]/,
+	regexpesc: /\\(?:[bBdDfnrstvwWn0\\\/]|@regexpctl|c[A-Z]|x[0-9a-fA-F]{2}|u[0-9a-fA-F]{4})/,
+
+	// The main tokenizer for our languages
+	tokenizer: {
+		root: [[/[{}]/, 'delimiter.bracket'], { include: 'common' }],
+
+		common: [
+			// identifiers and keywords
+			[
+				/#?[a-z_$][\w$]*/,
+				{
+					cases: {
+						'@keywords': 'keyword',
+						'@default': 'identifier'
+					}
+				}
+			],
+			[/[A-Z][\w\$]*/, 'type.identifier'], // to show class names nicely
+			// [/[A-Z][\w\$]*/, 'identifier'],
+
+			// whitespace
+			{ include: '@whitespace' },
+
+			// regular expression: ensure it is terminated before beginning (otherwise it is an opeator)
+			[
+				/\/(?=([^\\\/]|\\.)+\/([dgimsuy]*)(\s*)(\.|;|,|\)|\]|\}|$))/,
+				{ token: 'regexp', bracket: '@open', next: '@regexp' }
+			],
+
+			// delimiters and operators
+			[/[()\[\]]/, '@brackets'],
+			[/[<>](?!@symbols)/, '@brackets'],
+			[/!(?=([^=]|$))/, 'delimiter'],
+			[
+				/@symbols/,
+				{
+					cases: {
+						'@operators': 'delimiter',
+						'@default': ''
+					}
+				}
+			],
+
+			// numbers
+			[/(@digits)[eE]([\-+]?(@digits))?/, 'number.float'],
+			[/(@digits)\.(@digits)([eE][\-+]?(@digits))?/, 'number.float'],
+			[/0[xX](@hexdigits)n?/, 'number.hex'],
+			[/0[oO]?(@octaldigits)n?/, 'number.octal'],
+			[/0[bB](@binarydigits)n?/, 'number.binary'],
+			[/(@digits)n?/, 'number'],
+
+			// delimiter: after number because of .\d floats
+			[/[;,.]/, 'delimiter'],
+
+			// strings
+			[/"([^"\\]|\\.)*$/, 'string.invalid'], // non-teminated string
+			[/'([^'\\]|\\.)*$/, 'string.invalid'], // non-teminated string
+			[/"/, 'string', '@string_double'],
+			[/'/, 'string', '@string_single'],
+			[/`/, 'string', '@string_backtick']
+		],
+
+		whitespace: [
+			[/[ \t\r\n]+/, ''],
+			[/\/\*\*(?!\/)/, 'comment.doc', '@jsdoc'],
+			[/\/\*/, 'comment', '@comment'],
+			[/\/\/.*$/, 'comment']
+		],
+
+		comment: [
+			[/[^\/*]+/, 'comment'],
+			[/\*\//, 'comment', '@pop'],
+			[/[\/*]/, 'comment']
+		],
+
+		jsdoc: [
+			[/[^\/*]+/, 'comment.doc'],
+			[/\*\//, 'comment.doc', '@pop'],
+			[/[\/*]/, 'comment.doc']
+		],
+
+		// We match regular expression quite precisely
+		regexp: [
+			[
+				/(\{)(\d+(?:,\d*)?)(\})/,
+				['regexp.escape.control', 'regexp.escape.control', 'regexp.escape.control']
+			],
+			[
+				/(\[)(\^?)(?=(?:[^\]\\\/]|\\.)+)/,
+				['regexp.escape.control', { token: 'regexp.escape.control', next: '@regexrange' }]
+			],
+			[/(\()(\?:|\?=|\?!)/, ['regexp.escape.control', 'regexp.escape.control']],
+			[/[()]/, 'regexp.escape.control'],
+			[/@regexpctl/, 'regexp.escape.control'],
+			[/[^\\\/]/, 'regexp'],
+			[/@regexpesc/, 'regexp.escape'],
+			[/\\\./, 'regexp.invalid'],
+			[/(\/)([dgimsuy]*)/, [{ token: 'regexp', bracket: '@close', next: '@pop' }, 'keyword.other']]
+		],
+
+		regexrange: [
+			[/-/, 'regexp.escape.control'],
+			[/\^/, 'regexp.invalid'],
+			[/@regexpesc/, 'regexp.escape'],
+			[/[^\]]/, 'regexp'],
+			[
+				/\]/,
+				{
+					token: 'regexp.escape.control',
+					next: '@pop',
+					bracket: '@close'
+				}
+			]
+		],
+
+		string_double: [
+			[/[^\\"]+/, 'string'],
+			[/@escapes/, 'string.escape'],
+			[/\\./, 'string.escape.invalid'],
+			[/"/, 'string', '@pop']
+		],
+
+		string_single: [
+			[/[^\\']+/, 'string'],
+			[/@escapes/, 'string.escape'],
+			[/\\./, 'string.escape.invalid'],
+			[/'/, 'string', '@pop']
+		],
+
+		string_backtick: [
+			[/\$\{/, { token: 'delimiter.bracket', next: '@bracketCounting' }],
+			[/[^\\`$]+/, 'string'],
+			[/@escapes/, 'string.escape'],
+			[/\\./, 'string.escape.invalid'],
+			[/`/, 'string', '@pop']
+		],
+
+		bracketCounting: [
+			[/\{/, 'delimiter.bracket', '@bracketCounting'],
+			[/\}/, 'delimiter.bracket', '@pop'],
+			{ include: 'common' }
+		]
+	}
+};

--- a/website/src/website/data/home-samples/sample.pebble.txt
+++ b/website/src/website/data/home-samples/sample.pebble.txt
@@ -1,0 +1,54 @@
+/*
+	This is a sample pebble file
+*/
+
+
+struct Datum {
+    owner: string,
+}
+
+struct Animal {
+    Dog {
+        name: string,
+        barksCount: int,
+    }
+    Cat {
+        name: string,
+        color: string,
+    }
+    Fish {
+        name: string,
+    }
+}
+
+
+let a = 0;
+let b = 1;
+let c = 2;
+
+for (let i = 0; i < 10; i++) {
+    a += 1;
+}
+
+
+
+/* Folding markers */
+#region Initialization
+let x = 10
+let y = 20
+#endregion
+
+#region Calculation
+let sum = x + y
+print("Sum: " + sum)
+#endregion
+
+
+/* Conditional statements */
+if (a === 1) {
+    print("Condition passes")
+} else {
+    print("Failing")
+}
+
+


### PR DESCRIPTION
## To try out -

1. Build the editor in this repo, with pebble lsp

```
$ npm install
$ npm run build
$ npm run build-monaco-editor
```

~$ npm run simpleserver~
~Traverse to http://127.0.0.1:8088/monaco-editor/samples/browser-amd-editor/~

2. Link `monaco-editor` to test in examples repo (see last segment of [developing-language-support](https://github.com/microsoft/monaco-editor/blob/main/CONTRIBUTING.md#debugging--developing-language-support))
```
$ cd out/monaco-editor
$ npm link
```
_Note: Ensure installed node is `--lts`_  (`nvm use --lts`)

4. Clone the examples repo - https://github.com/amnambiar/monaco-pebble-example-repo

5. Setup examples repo and establish `monaco-editor` linking
```
$ npm install
$ npm link monaco-editor
```

6. Run the examples repo using [http-server](https://www.npmjs.com/package/http-server) or any other provider